### PR TITLE
Fixed missing dot and argument formatting in debug toolbar query logging

### DIFF
--- a/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
+++ b/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
@@ -29,6 +29,7 @@ class DebugToolbarWrapper(OperationDebugWrapper):
         self.logger = logger
 
     def log(self, op, duration, args, kwargs=None):
+        args = ", ".join(repr(arg) for arg in args)
         operation = f"db.{self.collection_name}{op}({args})"
         if self.logger:
             self.logger._queries.append(

--- a/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
+++ b/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
@@ -26,7 +26,7 @@ class DebugToolbarWrapper(OperationDebugWrapper):
 
     def __init__(self, db, collection, logger):
         super().__init__(db, collection)
-        self.collection_name = collection.name
+        self.collection_name = f"{collection.name}."
         self.logger = logger
 
     def log(self, op, duration, args, kwargs=None):

--- a/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
+++ b/django_mongodb_extensions/debug_toolbar/panels/mql/tracking.py
@@ -26,7 +26,6 @@ class DebugToolbarWrapper(OperationDebugWrapper):
 
     def __init__(self, db, collection, logger):
         super().__init__(db, collection)
-        self.collection_name = f"{collection.name}."
         self.logger = logger
 
     def log(self, op, duration, args, kwargs=None):


### PR DESCRIPTION
There's still a stray `,` at the end of the query, AFAICT.

```
(.venv) alex.clark@M-FD7GQ2QTFM django-mongodb-cli % ms   
Current Mongosh Log ID:	67dd5d15bb59f4a9ba24e6f4
Connecting to:		mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.4.2
Using MongoDB:		8.0.1
Using Mongosh:		2.4.2

For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/

------
   The server generated these startup warnings when booting
   2025-03-21T08:19:54.795-04:00: Access control is not enabled for the database. Read and write access to data and configuration is unrestricted
   2025-03-21T08:19:54.796-04:00: Soft rlimits for open file descriptors too low
------

test> use backend
switched to db backend
backend> db.auth_user.aggregate(([{'$match': {'$expr': {'$eq': ['$_id', ObjectId('67dd5b21fe36202ad9ee0859')]}}}, {'$limit': 21}],))
Uncaught:
SyntaxError: Unexpected token (1:121)

> 1 | db.auth_user.aggregate(([{'$match': {'$expr': {'$eq': ['$_id', ObjectId('67dd5b21fe36202ad9ee0859')]}}}, {'$limit': 21}],))
    |                                                                                                                          ^
  2 |

backend> db.auth_user.aggregate(([{'$match': {'$expr': {'$eq': ['$_id', ObjectId('67dd5b21fe36202ad9ee0859')]}}}, {'$limit': 21}]))
[
  {
    _id: ObjectId('67dd5b21fe36202ad9ee0859'),
    password: 'pbkdf2_sha256$870000$qkYv60fh4oDUTUN8c0sjpf$emYQCetff+gWiQZGsTiy2xcT4RmMCjx3KSUXw3A0Wqg=',
    last_login: ISODate('2025-03-21T12:27:17.829Z'),
    is_superuser: true,
    username: 'admin',
    first_name: '',
    last_name: '',
    email: 'aclark@aclark.net',
    is_staff: true,
    is_active: true,
    date_joined: ISODate('2025-03-21T12:27:13.279Z')
  }
]
backend> 
```